### PR TITLE
Fix license autoaccept

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -58,7 +58,7 @@ end
 
 execute "#{splunk_cmd} start --accept-license --answer-yes" do
   not_if do
-    `#{splunk_cmd} status | grep 'splunkd'`.chomp! =~ /^splunkd is running/
+    File.exists?("#{node['splunkstorm']['forwarder_root']}/var/run/splunk/splunkd.pid")
   end
 end
 


### PR DESCRIPTION
Hello, this was a really nasty one because of Chef's poor error messages. The start will only be executed if the status command works fine... and the status commands asks to accept the license. 

I've fixed it for me by checking for the PID file, which also seem like a cleaner way to check if the daemon is running. 

This was the not very helpful debug message from chef:
[Tue, 12 Feb 2013 15:30:06 +0000] DEBUG: Processing execute[/opt/splunkforwarder/bin/splunk start --accept-license --answer-yes] on xxxxxxxx
Do you agree with this license? [y/n]:

Hope this helps
Thanks
