### PR TITLE
Fix trip up on first run

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -58,7 +58,7 @@ end
 
 execute "#{splunk_cmd} start --accept-license --answer-yes" do
   not_if do
-    `#{splunk_cmd} status | grep 'splunkd'`.chomp! =~ /^splunkd is running/
+    `#{splunk_cmd} status --accept-license | grep 'splunkd'`.chomp! =~ /^splunkd is running/
   end
 end
 


### PR DESCRIPTION
If splunk has only just been installed, the first command is `status`, not `start`, because it has to run the `not_if` to determine if `start` should be run at all.

I saw this with splunkforwarder 5.0.3. It may or may not have been present in earlier versions.
