### PR TITLE
add ability to specify spl file location on file system

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -12,6 +12,9 @@ default['splunkstorm']['forwarder_root']       = "http://download.splunk.com/rel
 default['splunkstorm']['forwarder_version']    = "4.3.3"
 default['splunkstorm']['forwarder_build']      = "128297"
 
+# location of license file (to bypass databag lookup)
+default['splunkstorm']['license_file']         = nil
+
 # Splunk License Data Bag
 default['splunkstorm']['license_databag']      = "licenses"
 default['splunkstorm']['license_databag_item'] = "storm"

--- a/providers/monitor.rb
+++ b/providers/monitor.rb
@@ -31,7 +31,7 @@ end
 
 action :add do
   additional_params = new_resource.params.map{|k,v| "-#{k} #{v}"}.join(' ')
-  if !already_monitors_path?(new_resource.path)
+  unless already_monitors_path?(new_resource.path)
     execute "splunk add monitor #{new_resource.path}" do
       command "#{node['splunkstorm']['forwarder_home']}/bin/splunk add monitor #{new_resource.path} -auth #{node['splunkstorm']['auth']} #{additional_params}"
       action :run

--- a/readme.md
+++ b/readme.md
@@ -1,7 +1,7 @@
 Note:
 ===========
 
-This cookbook is no longer maintaned by us as we no longer use Splunk Storm.
+This cookbook is no longer maintained by us as we no longer use Splunk Storm.
 Best to look at one of the more up-to-date forks instead.
 
 Description
@@ -10,9 +10,16 @@ Description
 This little Chef Cookbook provides recipes and definitions to install Splunk Forwarders and setup monitors for Splunk Storm.
 
 As you know, Splunk Storm uses a proprietary credentials file to setup access to the Splunk Storm servers/account.
-You probably won't want to have this file floating around in your cookbook unencrypted, so we're going to stuff the contents of the credentials file into a Secure Databag.
 
-To do that, you'll need to:
+There are two ways to point at the credentials file:
+
+## Specify a File Location (useful for a chef solo env (e.g. OpsWorks))
+
+1. Get the spl file to a known location on the file system (from s3, mounted network drive, etc)
+
+2. Specify the path to the spl file in `node['splunkstorm']['license_file']`
+
+## Use a Secure Data Bag (good solution for hosted or private chef)
 
 1. Create the data bag using knife
         
@@ -45,6 +52,7 @@ To do that, you'll need to:
 Changes
 =======
 
+* v0.0.2 - Add ability to specify license file location
 * v0.0.1 - Initial Release
 
 
@@ -75,7 +83,7 @@ See `attributes/default.rb` for default values.
 * `node['splunkstorm']['forwarder_root']` - The base URL that splunk uses to download release files for Splunk Forwarder
 * `node['splunkstorm']['forwarder_version']` - The specific version of Splunk Forwarder to download
 * `node['splunkstorm']['forwarder_build]` - The specific build number of Splunk Forwarder to download
-
+* `node['splunkstorm']['license_file']` - [optional] absolute path to spl credentials file
 
 Recipes
 =======

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -16,10 +16,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-directory "/opt" do
-  mode "0755"
-  owner "root"
-  group "root"
+directory '/opt' do
+  mode '0755'
+  owner 'root'
+  group 'root'
 end
 
 splunk_cmd = "#{node['splunkstorm']['forwarder_home']}/bin/splunk"
@@ -27,18 +27,20 @@ splunk_package_version = "splunkforwarder-#{node['splunkstorm']['forwarder_versi
 
 splunk_file = splunk_package_version + 
   case node['platform_family']
-  when "rhel"
-    if node['kernel']['machine'] == "x86_64"
-      "-linux-2.6-x86_64.rpm"
+  when 'rhel'
+    if node['kernel']['machine'] == 'x86_64'
+      '-linux-2.6-x86_64.rpm'
     else
-      ".i386.rpm"
+      '.i386.rpm'
     end
-  when "debian"
-    if node['kernel']['machine'] == "x86_64"
-      "-linux-2.6-amd64.deb"
+  when 'debian'
+    if node['kernel']['machine'] == 'x86_64'
+      '-linux-2.6-amd64.deb'
     else
-      "-linux-2.6-intel.deb"
+      '-linux-2.6-intel.deb'
     end
+    else
+      raise "Unknown platform: #{node['platform_family']}"
   end
 
 remote_file "/opt/#{splunk_file}" do
@@ -49,10 +51,12 @@ end
 package splunk_package_version do
   source "/opt/#{splunk_file}"
   case node['platform_family']
-  when "rhel"
+  when 'rhel'
     provider Chef::Provider::Package::Rpm
-  when "debian"
+  when 'debian'
     provider Chef::Provider::Package::Dpkg
+    else
+      raise "Unknown platform: #{node['platform_family']}"
   end
 end
 
@@ -68,51 +72,58 @@ execute "#{splunk_cmd} enable boot-start" do
   end
 end
 
-service "splunk" do
+service 'splunk' do
   action [ :nothing ]
   supports :status => true, :start => true, :stop => true, :restart => true
 end
 
-license_details = Chef::EncryptedDataBagItem.load(node['splunkstorm']['license_databag'], node['splunkstorm']['license_databag_item'])
-ruby_block "create storm certificates" do
-  block do
-    File.open("#{node['splunkstorm']['forwarder_home']}/#{license_details['filename']}", "wb") do |file|
-      file.write(license_details['data'].unpack('m').first)
+if node['splunkstorm']['license_file']
+  # the license file location was specified by the node config
+  license_file = node['splunkstorm']['license_file']
+else
+  # look up license file in data bag
+  license_details = Chef::EncryptedDataBagItem.load(node['splunkstorm']['license_databag'], node['splunkstorm']['license_databag_item'])
+  license_file = "#{node['splunkstorm']['forwarder_home']}/#{license_details['filename']}"
+  ruby_block 'create storm certificates' do
+    block do
+      File.open(license_file, 'wb') do |file|
+        file.write(license_details['data'].unpack('m').first)
+      end
     end
+    action :create
   end
-  action :create
-end
 
-bash "fix license" do
-  user "root"
-  cwd "#{node['splunkstorm']['forwarder_home']}"
-  code <<-EOH
-  chown root:root #{node['splunkstorm']['forwarder_home']}/#{license_details['filename']}
-  chmod 0644 #{node['splunkstorm']['forwarder_home']}/#{license_details['filename']}
-  EOH
+  bash 'fix license' do
+    user 'root'
+    cwd "#{node['splunkstorm']['forwarder_home']}"
+    code <<-EOH
+      chown root:root #{license_file}
+      chmod 0644 #{license_file}
+    EOH
+  end
 end
 
 splunk_password = node['splunkstorm']['auth'].split(':')[1]
 execute "#{splunk_cmd} edit user admin -password #{splunk_password} -roles admin -auth admin:changeme && echo true > /opt/splunk_setup_passwd" do
   not_if do
-    File.exists?("/opt/splunk_setup_passwd")
+    File.exists?('/opt/splunk_setup_passwd')
   end
 end
 
-execute "#{splunk_cmd} install app #{node['splunkstorm']['forwarder_home']}/#{license_details['filename']} -auth #{node['splunkstorm']['auth']} && echo true > /opt/splunk_setup_license" do
+execute "#{splunk_cmd} install app #{license_file} -auth #{node['splunkstorm']['auth']} && echo true > /opt/splunk_setup_license" do
   not_if do
-    File.exists?("/opt/splunk_setup_license")
+    File.exists?('/opt/splunk_setup_license')
   end
 end
 
-template "/etc/init.d/splunk" do
-  source "splunk.erb"
-  mode "0755"
-  owner "root"
-  group "root"
+template '/etc/init.d/splunk' do
+  source 'splunk.erb'
+  mode '0755'
+  owner 'root'
+  group 'root'
 end
 
-template "/etc/profile.d/splunk.sh" do
-  source "splunk.sh.erb"
+template '/etc/profile.d/splunk.sh' do
+  source 'splunk.sh.erb'
   mode 0644
 end


### PR DESCRIPTION
For chef solo instances (AWS OpsWorks) we needed a way to fetch the SPL file from S3 and just point to its location when setting up the forwarder. This pull request enables pointing at any file system path instead of using the data bag to get the SPL file.
